### PR TITLE
Configuracao do postgres via Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  db:
+    container_name: postgres
+    image: postgres:alpine
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: test_db
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres-compose-network
+
+  pgadmin:
+    container_name: pgadmin4
+    image: dpage/pgadmin4
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.compose
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "15432:80"
+    networks:
+      - postgres-compose-network
+
+networks:
+  postgres-compose-network:
+    driver: bridge

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
-
+# DATASOURCE
+spring.datasource.url=jdbc:postgresql://localhost:5432/agenda
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Este PR adiciona o arquivo docker-compose.yml para os container do PostgreSQL e PgAdmin. Além disso, também é adicionado as configurações das propriedades da aplicação para que o projeto Spring consiga se conectar aos bancos mencionados.